### PR TITLE
compute overall compared to league avg

### DIFF
--- a/src/basketball/worker/core/player/ovr.js
+++ b/src/basketball/worker/core/player/ovr.js
@@ -13,22 +13,23 @@ import type { PlayerRatings } from "../../../common/types";
 const ovr = (ratings: PlayerRatings): number => {
     // This formula is loosely based on linear regression of ratings to zscore(ws48)+zscore(per):
     const r =
-        (5 * ratings.hgt +
-            1 * ratings.stre +
-            4 * ratings.spd +
-            2 * ratings.jmp +
-            1 * ratings.endu +
-            1 * ratings.ins +
-            2 * ratings.dnk +
-            1 * ratings.ft +
-            1 * ratings.fg +
-            3 * ratings.tp +
-            7 * ratings.oiq +
-            3 * ratings.diq +
-            3 * ratings.drb +
-            3 * ratings.pss +
-            1 * ratings.reb) /
-        38;
+        ((5 * (ratings.hgt - 47)) / 14 +
+            (1 * (ratings.stre - 50)) / 11 +
+            (4 * (ratings.spd - 53)) / 16 +
+            (2 * (ratings.jmp - 51)) / 17 +
+            (1 * (ratings.endu - 42)) / 12 +
+            (1 * (ratings.ins - 43)) / 13 +
+            (2 * (ratings.dnk - 50)) / 13 +
+            (1 * (ratings.ft - 48)) / 13 +
+            (1 * (ratings.fg - 48)) / 13 +
+            (3 * (ratings.tp - 48)) / 13 +
+            (7 * (ratings.oiq - 47)) / 10 +
+            (3 * (ratings.diq - 47)) / 11 +
+            (3 * (ratings.drb - 56)) / 11 +
+            (3 * (ratings.pss - 52)) / 12 +
+            (1 * (ratings.reb - 51)) / 12) *
+            0.292 +
+        48.1;
 
     // Fudge factor to keep ovr ratings the same as they used to be (back before 2018 ratings rescaling)
     // +8 at 68


### PR DESCRIPTION
Not sure this makes a big difference with these weights but should be better.

Distributions should match
![image](https://user-images.githubusercontent.com/50534560/62000953-a88d2380-b0b2-11e9-9fc9-af6c479e72b3.png)
