### PR TITLE
OVR computation change

### DIFF
--- a/src/basketball/worker/core/player/ovr.js
+++ b/src/basketball/worker/core/player/ovr.js
@@ -13,22 +13,22 @@ import type { PlayerRatings } from "../../../common/types";
 const ovr = (ratings: PlayerRatings): number => {
     // This formula is loosely based on linear regression of ratings to zscore(ws48)+zscore(per):
     const r =
-        ((5 * (ratings.hgt - 47)) / 14 +
-            (1 * (ratings.stre - 50)) / 11 +
-            (4 * (ratings.spd - 53)) / 16 +
-            (2 * (ratings.jmp - 51)) / 17 +
-            (1 * (ratings.endu - 42)) / 12 +
-            (1 * (ratings.ins - 43)) / 13 +
-            (2 * (ratings.dnk - 50)) / 13 +
-            (1 * (ratings.ft - 48)) / 13 +
-            (1 * (ratings.fg - 48)) / 13 +
-            (3 * (ratings.tp - 48)) / 13 +
-            (7 * (ratings.oiq - 47)) / 10 +
-            (3 * (ratings.diq - 47)) / 11 +
-            (3 * (ratings.drb - 56)) / 11 +
-            (3 * (ratings.pss - 52)) / 12 +
-            (1 * (ratings.reb - 51)) / 12) *
-            0.292 +
+        ((0.19 * (ratings.hgt - 47)) / 14 +
+            (0.07 * (ratings.stre - 50)) / 11 +
+            (0.18 * (ratings.spd - 53)) / 16 +
+            (0.15 * (ratings.jmp - 51)) / 17 +
+            (0.02 * (ratings.endu - 42)) / 12 +
+            (0.04 * (ratings.ins - 43)) / 13 +
+            (0.02 * (ratings.dnk - 50)) / 13 +
+            (0.01 * (ratings.ft - 48)) / 13 +
+            (0.01 * (ratings.fg - 48)) / 13 +
+            (0.1 * (ratings.tp - 48)) / 13 +
+            (0.06 * (ratings.oiq - 47)) / 10 +
+            (0.11 * (ratings.diq - 47)) / 11 +
+            (0.06 * (ratings.drb - 56)) / 11 +
+            (0.02 * (ratings.pss - 52)) / 12 +
+            (0.05 * (ratings.reb - 51)) / 12) *
+            12.36 +
         48.1;
 
     // Fudge factor to keep ovr ratings the same as they used to be (back before 2018 ratings rescaling)

--- a/src/basketball/worker/core/player/ovr.js
+++ b/src/basketball/worker/core/player/ovr.js
@@ -13,23 +13,23 @@ import type { PlayerRatings } from "../../../common/types";
 const ovr = (ratings: PlayerRatings): number => {
     // This formula is loosely based on linear regression of ratings to zscore(ws48)+zscore(per):
     const r =
-        ((0.18 * (ratings.hgt - 47)) / 14 +
-            (0.05 * (ratings.stre - 50)) / 11 +
-            (0.15 * (ratings.spd - 53)) / 16 +
-            (0.13 * (ratings.jmp - 51)) / 17 +
-            (0.02 * (ratings.endu - 41)) / 13 +
-            (0.02 * (ratings.ins - 42)) / 13 +
-            (0.02 * (ratings.dnk - 49)) / 13 +
-            (0.01 * (ratings.ft - 47)) / 13 +
-            (0.01 * (ratings.fg - 47)) / 13 +
-            (0.09 * (ratings.tp - 47)) / 13 +
-            (0.09 * (ratings.oiq - 46)) / 11 +
-            (0.09 * (ratings.diq - 46)) / 11 +
-            (0.06 * (ratings.drb - 55)) / 11 +
-            (0.03 * (ratings.pss - 51)) / 12 +
-            (0.05 * (ratings.reb - 51)) / 12) *
-            13.55 +
-        47.47;
+        ((0.23 * (ratings.hgt - 47)) / 14 +
+            (0.1 * (ratings.stre - 49)) / 11 +
+            (0.22 * (ratings.spd - 51)) / 17 +
+            (0.12 * (ratings.jmp - 48)) / 18 +
+            (0.05 * (ratings.endu - 41)) / 13 +
+            (0.03 * (ratings.ins - 42)) / 14 +
+            (0.03 * (ratings.dnk - 49)) / 13 +
+            (0.01 * (ratings.ft - 47)) / 12 +
+            (0.01 * (ratings.fg - 47)) / 12 +
+            (0.09 * (ratings.tp - 47)) / 12 +
+            (0.09 * (ratings.oiq - 47)) / 10 +
+            (0.13 * (ratings.diq - 47)) / 10 +
+            (0.07 * (ratings.drb - 55)) / 11 +
+            (0.07 * (ratings.pss - 51)) / 12 +
+            (0.02 * (ratings.reb - 51)) / 12) *
+            10.18 +
+        48.36;
 
     // Fudge factor to keep ovr ratings the same as they used to be (back before 2018 ratings rescaling)
     // +8 at 68

--- a/src/basketball/worker/core/player/ovr.js
+++ b/src/basketball/worker/core/player/ovr.js
@@ -13,23 +13,23 @@ import type { PlayerRatings } from "../../../common/types";
 const ovr = (ratings: PlayerRatings): number => {
     // This formula is loosely based on linear regression of ratings to zscore(ws48)+zscore(per):
     const r =
-        ((0.19 * (ratings.hgt - 47)) / 14 +
-            (0.07 * (ratings.stre - 50)) / 11 +
-            (0.18 * (ratings.spd - 53)) / 16 +
-            (0.15 * (ratings.jmp - 51)) / 17 +
-            (0.02 * (ratings.endu - 42)) / 12 +
-            (0.04 * (ratings.ins - 43)) / 13 +
-            (0.02 * (ratings.dnk - 50)) / 13 +
-            (0.01 * (ratings.ft - 48)) / 13 +
-            (0.01 * (ratings.fg - 48)) / 13 +
-            (0.1 * (ratings.tp - 48)) / 13 +
-            (0.06 * (ratings.oiq - 47)) / 10 +
-            (0.11 * (ratings.diq - 47)) / 11 +
-            (0.06 * (ratings.drb - 56)) / 11 +
-            (0.02 * (ratings.pss - 52)) / 12 +
+        ((0.18 * (ratings.hgt - 47)) / 14 +
+            (0.05 * (ratings.stre - 50)) / 11 +
+            (0.15 * (ratings.spd - 53)) / 16 +
+            (0.13 * (ratings.jmp - 51)) / 17 +
+            (0.02 * (ratings.endu - 41)) / 13 +
+            (0.02 * (ratings.ins - 42)) / 13 +
+            (0.02 * (ratings.dnk - 49)) / 13 +
+            (0.01 * (ratings.ft - 47)) / 13 +
+            (0.01 * (ratings.fg - 47)) / 13 +
+            (0.09 * (ratings.tp - 47)) / 13 +
+            (0.09 * (ratings.oiq - 46)) / 11 +
+            (0.09 * (ratings.diq - 46)) / 11 +
+            (0.06 * (ratings.drb - 55)) / 11 +
+            (0.03 * (ratings.pss - 51)) / 12 +
             (0.05 * (ratings.reb - 51)) / 12) *
-            12.36 +
-        48.1;
+            13.55 +
+        47.47;
 
     // Fudge factor to keep ovr ratings the same as they used to be (back before 2018 ratings rescaling)
     // +8 at 68

--- a/src/basketball/worker/core/player/ovr.js
+++ b/src/basketball/worker/core/player/ovr.js
@@ -13,22 +13,23 @@ import type { PlayerRatings } from "../../../common/types";
 const ovr = (ratings: PlayerRatings): number => {
     // This formula is loosely based on linear regression of ratings to zscore(ws48)+zscore(per):
     const r =
-        (5 * ratings.hgt +
-            1 * ratings.stre +
-            4 * ratings.spd +
-            2 * ratings.jmp +
-            1 * ratings.endu +
-            1 * ratings.ins +
-            2 * ratings.dnk +
-            1 * ratings.ft +
-            1 * ratings.fg +
-            3 * ratings.tp +
-            7 * ratings.oiq +
-            3 * ratings.diq +
-            3 * ratings.drb +
-            3 * ratings.pss +
-            1 * ratings.reb) /
-        38;
+        ((5 * (ratings.hgt - 47)) / 14 +
+            (1 * (ratings.stre - 50)) / 11 +
+            (4 * (ratings.spd - 53)) / 16 +
+            (2 * (ratings.jmp - 51)) / 17 +
+            (1 * (ratings.endu - 42)) / 12 +
+            (1 * (ratings.ins - 43)) / 13 +
+            (2 * (ratings.dnk - 50)) / 13 +
+            (1 * (ratings.ft - 48)) / 13 +
+            (1 * (ratings.fg - 48)) / 13 +
+            (3 * (ratings.tp - 48)) / 13 +
+            (7 * (ratings.oiq - 47)) / 10 +
+            (3 * (ratings.diq - 47)) / 11 +
+            (3 * (ratings.drb - 56)) / 11 +
+            (3 * (ratings.pss - 52)) / 12 +
+            (1 * (ratings.reb - 51)) / 12) *
+            0.292 +
+        48.1;
 
     // Fudge factor to keep ovr ratings the same as they used to be (back before 2018 ratings rescaling)
     // +8 at 68


### PR DESCRIPTION
Basically #253 but with weights coming from a giant +/- regression.

So two changes happening here:
1. Overall gets computed relative to league average statistics. So now it's "how many standard deviations above or below league-average" instead of just the raw numbers. I found this helpful in building reliable regressions. 
2. The weights come from using +/- regression instead of PER+WS/48. This rewards some of the statistics involved in defense a little bit higher than the current method. 

The distribution should match, so none of the other code should need to be changed. 
![image](https://user-images.githubusercontent.com/50534560/62001118-a927b900-b0b6-11e9-9547-8c185a54632e.png)

Code and data are here:
https://github.com/nicidob/bbgm/blob/master/regress_WAR.ipynb
