### PR TITLE
Added years with team to the resign player page

### DIFF
--- a/src/deion/common/getCols.js
+++ b/src/deion/common/getCols.js
@@ -1347,6 +1347,9 @@ const cols: {
         sortSequence: ["desc", "asc"],
         sortType: "number",
     },
+    YWT: {
+        desc: "Years With Team"
+    },
     "rating:hgt": {
         desc: "Height",
         sortSequence: ["desc", "asc"],
@@ -1379,6 +1382,11 @@ const cols: {
     },
     "stat:mov": {
         desc: "Margin of Victory",
+        sortSequence: ["desc", "asc"],
+        sortType: "number",
+    },
+    "stat:yearsWithTeam": {
+        desc: "yearsWithTeam",
         sortSequence: ["desc", "asc"],
         sortType: "number",
     },

--- a/src/deion/common/getCols.js
+++ b/src/deion/common/getCols.js
@@ -1347,9 +1347,6 @@ const cols: {
         sortSequence: ["desc", "asc"],
         sortType: "number",
     },
-    YWT: {
-        desc: "Years With Team"
-    },
     "rating:hgt": {
         desc: "Height",
         sortSequence: ["desc", "asc"],
@@ -1386,7 +1383,7 @@ const cols: {
         sortType: "number",
     },
     "stat:yearsWithTeam": {
-        desc: "yearsWithTeam",
+        desc: "Years With Team",
         sortSequence: ["desc", "asc"],
         sortType: "number",
     },
@@ -1723,6 +1720,7 @@ const titleOverrides = {
     "stat:gs": "GS",
     "stat:min": "MP",
     "stat:mov": "MOV",
+    "stat:yearsWithTeam": "YWT",
     "count:allDefense": "ADT",
     "count:allLeague": "ALT",
     "count:allRookie": "ART",

--- a/src/deion/ui/util/helpers.js
+++ b/src/deion/ui/util/helpers.js
@@ -68,6 +68,7 @@ const roundOverrides =
         ? {
               gp: "none",
               gs: "none",
+              yearsWithTeam: "none",
               gmsc: "oneDecimalPlace",
               fgp: "oneDecimalPlace",
               tpp: "oneDecimalPlace",
@@ -79,6 +80,7 @@ const roundOverrides =
         : {
               gp: "none",
               gs: "none",
+              yearsWithTeam: "none",
               cmpPct: "oneDecimalPlace",
               qbRat: "oneDecimalPlace",
               rusYdsPerAtt: "oneDecimalPlace",

--- a/src/deion/ui/views/NegotiationList.js
+++ b/src/deion/ui/views/NegotiationList.js
@@ -27,15 +27,10 @@ const NegotiationList = ({
 
     setTitle(title);
 
-    stats = stats.filter((stat) => {
-        return stat !== "yearsWithTeam";
-    });
-
     const cols = getCols(
         "Name",
         "Pos",
         "Age",
-        "YWT",
         "Ovr",
         "Pot",
         ...stats.map(stat => `stat:${stat}`),
@@ -58,7 +53,6 @@ const NegotiationList = ({
                 </PlayerNameLabels>,
                 p.ratings.pos,
                 p.age,
-                p.stats.yearsWithTeam,
                 p.ratings.ovr,
                 p.ratings.pot,
                 ...stats.map(stat => helpers.roundStat(p.stats[stat], stat)),

--- a/src/deion/ui/views/NegotiationList.js
+++ b/src/deion/ui/views/NegotiationList.js
@@ -27,10 +27,15 @@ const NegotiationList = ({
 
     setTitle(title);
 
+    stats = stats.filter((stat) => {
+        return stat !== "yearsWithTeam";
+    });
+
     const cols = getCols(
         "Name",
         "Pos",
         "Age",
+        "YWT",
         "Ovr",
         "Pot",
         ...stats.map(stat => `stat:${stat}`),
@@ -53,6 +58,7 @@ const NegotiationList = ({
                 </PlayerNameLabels>,
                 p.ratings.pos,
                 p.age,
+                p.stats.yearsWithTeam,
                 p.ratings.ovr,
                 p.ratings.pot,
                 ...stats.map(stat => helpers.roundStat(p.stats[stat], stat)),

--- a/src/deion/worker/views/negotiationList.js
+++ b/src/deion/worker/views/negotiationList.js
@@ -8,8 +8,8 @@ import { g } from "../util";
 async function updateNegotiationList(): void | { [key: string]: any } {
     const stats =
         process.env.SPORT === "basketball"
-            ? ["gp", "min", "pts", "trb", "ast", "per"]
-            : ["gp", "keyStats", "av"];
+          ? ["gp", "min", "pts", "trb", "ast", "per", "yearsWithTeam"]
+          : ["gp", "keyStats", "av", "yearsWithTeam"];
 
     let negotiations = await idb.cache.negotiations.getAll();
 

--- a/src/deion/worker/views/negotiationList.js
+++ b/src/deion/worker/views/negotiationList.js
@@ -8,8 +8,8 @@ import { g } from "../util";
 async function updateNegotiationList(): void | { [key: string]: any } {
     const stats =
         process.env.SPORT === "basketball"
-          ? ["gp", "min", "pts", "trb", "ast", "per", "yearsWithTeam"]
-          : ["gp", "keyStats", "av", "yearsWithTeam"];
+            ? ["yearsWithTeam", "gp", "min", "pts", "trb", "ast", "per"]
+            : ["yearsWithTeam", "gp", "keyStats", "av"];
 
     let negotiations = await idb.cache.negotiations.getAll();
 


### PR DESCRIPTION
Inspired by https://www.reddit.com/r/BasketballGM/comments/cjcxs6/suggestion_add_years_with_team_to_resign_players/

As evidenced by the title, this change adds the years with team as a column in the resign players page, in both the Basketball and Football versions. I've also tested it a fair amount (passes the linter, passes all tests, YWT shows up in the resign page, but not the generic FA page). 

Overall, the change isn't too complicated I don't think. It adds "YWT" as a column in "getCols.js", so that the call to "getCols" in "NegotiationList.js" does not complain. In the same file, it adds "yearsWithTeam" as a stat shared between both sports (for obvious reasons). 

From there, I added "yearsWithTeam" to the "stats" array which gets passed to "playersPlus", so that we would have access to it inside the "NegotiateList" function.

From there, the only issue was that the call to map for the other stats like MP, PTS, AST, etc would not work with the "yearsWithTeam" field as it would try to print the long name in the title, and convert the value to a float. My solution was to leave as much of the code the same as possible and simply call filter on the stats array to remove "yearsWithTeam", and then add it as a separate column (with name "YWT"), grabbing the value from "p.stats.yearsWithTeam".

Lemme know any thoughts/concerns on the change!