### PR TITLE
Betterdraftsalaries

### DIFF
--- a/src/deion/worker/core/draft/getRookieSalaries.js
+++ b/src/deion/worker/core/draft/getRookieSalaries.js
@@ -11,7 +11,7 @@ import { g } from "../../util";
  * @return {Array.<number>} Array of salaries, in thousands of dollars/year.
  */
 const getRookieSalaries = (): number[] => {
-	// Default for 60 picks
+	// Default for first round
 	const firstRoundRookieSalaries = [
 		5000,
 		4500,
@@ -43,7 +43,8 @@ const getRookieSalaries = (): number[] => {
 		1000,
 		1000,
 		1000]
-	
+	  
+	  //default for all subsequent rounds
 	const otherRoundRookieSalaries = [
 		500,
 		500,

--- a/src/deion/worker/core/draft/getRookieSalaries.js
+++ b/src/deion/worker/core/draft/getRookieSalaries.js
@@ -12,7 +12,7 @@ import { g } from "../../util";
  */
 const getRookieSalaries = (): number[] => {
 	// Default for 60 picks
-	const rookieSalaries = [
+	const firstRoundRookieSalaries = [
 		5000,
 		4500,
 		4000,
@@ -42,7 +42,9 @@ const getRookieSalaries = (): number[] => {
 		1000,
 		1000,
 		1000,
-		1000,
+		1000]
+	
+	const otherRoundRookieSalaries = [
 		500,
 		500,
 		500,
@@ -75,14 +77,27 @@ const getRookieSalaries = (): number[] => {
 		500,
 	];
 
-	while (g.numTeams * g.numDraftRounds > rookieSalaries.length) {
+	while (g.numTeams > firstRoundRookieSalaries.length){
+		//add first round contracts on to end of first round
+		firstRoundRookieSalaries.push(1000);
+	}
+	
+	while (g.numTeams < firstRoundRookieSalaries.length){
+		//remove smallest first round salaries
+		firstRoundRookieSalaries.pop();
+	}
+	
+	while (g.numTeams * (g.numDraftRounds-1) > otherRoundRookieSalaries.length) {
 		// Add min contracts on to end
-		rookieSalaries.push(500);
+		otherRoundRookieSalaries.push(500);
 	}
-	while (g.numTeams * g.numDraftRounds < rookieSalaries.length) {
+	while (g.numTeams * (g.numDraftRounds-1) < otherRoundRookieSalaries.length) {
 		// Remove smallest salaries
-		rookieSalaries.pop();
+		otherRoundRookieSalaries.pop();
 	}
+	
+	//combine first round and other rounds
+	const rookieSalaries = firstRoundRookieSalaries.concat(otherRoundRookieSalaries);
 
 	if (g.minContract !== 500 || g.maxContract !== 20000) {
 		for (let i = 0; i < rookieSalaries.length; i++) {


### PR DESCRIPTION
Separates first and other rounds in determining salaries of draft picks to make sure all first rounders make at least the default first round salary and all other rounders make league minimum.