### PR TITLE
tweak shooting %s to match NBA

### DIFF
--- a/src/common/constants.basketball.ts
+++ b/src/common/constants.basketball.ts
@@ -30,20 +30,20 @@ const COMPOSITE_WEIGHTS: CompositeWeights<RatingKey> = {
 		weights: [0.5, 1, 1, -1],
 	},
 	shootingAtRim: {
-		ratings: ["hgt", "spd", "jmp", "dnk", "oiq"],
-		weights: [0.75, 0.2, 0.6, 0.4, 0.2],
+		ratings: ["hgt", "stre", "dnk", "oiq"],
+		weights: [2, 0.3, 0.3, 0.2],
 	},
 	shootingLowPost: {
 		ratings: ["hgt", "stre", "spd", "ins", "oiq"],
-		weights: [2, 0.6, 0.2, 1, 0.2],
+		weights: [1, 0.6, 0.2, 1, 0.4],
 		skill: {
 			label: "Po",
 			cutoff: 0.61,
 		},
 	},
 	shootingMidRange: {
-		ratings: ["oiq", "fg"],
-		weights: [-0.5, 1],
+		ratings: ["oiq", "fg", "stre"],
+		weights: [-0.5, 1, 0.2],
 	},
 	shootingThreePointer: {
 		ratings: ["oiq", "tp"],

--- a/src/worker/core/GameSim.basketball.ts
+++ b/src/worker/core/GameSim.basketball.ts
@@ -1193,15 +1193,15 @@ class GameSim {
 				probMissAndFoul = 0.07;
 				probMake =
 					this.team[this.o].player[p].compositeRating.shootingMidRange * 0.32 +
-					0.35;
+					0.42;
 				probAndOne = 0.05;
 			} else if (r2 > r3) {
 				// Dunk, fast break or half court
 				type = "atRim";
 				probMissAndFoul = 0.37;
 				probMake =
-					this.team[this.o].player[p].compositeRating.shootingAtRim * 0.32 +
-					0.55;
+					this.team[this.o].player[p].compositeRating.shootingAtRim * 0.41 +
+					0.54;
 				probAndOne = 0.25;
 			} else {
 				// Post up
@@ -1209,7 +1209,7 @@ class GameSim {
 				probMissAndFoul = 0.33;
 				probMake =
 					this.team[this.o].player[p].compositeRating.shootingLowPost * 0.32 +
-					0.42;
+					0.34;
 				probAndOne = 0.15;
 			}
 


### PR DESCRIPTION
I tweaked the Rim%, LowPost% and MidRange% composite ratings and percentages to better match NBA. Here are some plots showing before/after with 10 seasons of random players simulated and  NBA 2006 to 2019 stats for comparison. 
![shooting](https://user-images.githubusercontent.com/50534560/87237771-069c3f00-c3c8-11ea-8ac3-9335d8d5e8c2.png)

Previously
- Rim shooting didn't take sufficient account of height
- Low Post shooting was too high and too dependent on height
- Mid Range shooting was too low (and too height dependent but I didn't totally fix that)