### PR TITLE
update fatigue formulas to better match NBA

### DIFF
--- a/src/worker/core/GameSim.basketball.ts
+++ b/src/worker/core/GameSim.basketball.ts
@@ -546,7 +546,7 @@ class GameSim {
 	 * @return {number} Fatigue, from 0 to 1 (0 = lots of fatigue, 1 = none).
 	 */
 	fatigue(energy: number, skip?: boolean): number {
-		energy += 0.1;
+		energy += 0.06;
 
 		if (energy > 1) {
 			energy = 1;
@@ -684,7 +684,7 @@ class GameSim {
 
 						if ((numG < 2 && numPG === 0) || (numF < 2 && numC === 0)) {
 							if (
-								this.fatigue(this.team[t].player[p].stat.energy) > 0.63 &&
+								this.fatigue(this.team[t].player[p].stat.energy) > 0.67 &&
 								!onCourtIsIneligible
 							) {
 								// Exception for ridiculously tired players, so really unbalanced teams won't play starters whole game
@@ -924,7 +924,7 @@ class GameSim {
 						"energy",
 						-possessionLength *
 							0.055 *
-							(1 - this.team[t].player[p].compositeRating.endurance) ** 1.0,
+							(1 - this.team[t].player[p].compositeRating.endurance),
 					);
 
 					if (this.team[t].player[p].stat.energy < 0) {
@@ -932,7 +932,7 @@ class GameSim {
 					}
 				} else {
 					this.recordStat(t, p, "benchTime", possessionLength);
-					this.recordStat(t, p, "energy", possessionLength * 0.075);
+					this.recordStat(t, p, "energy", possessionLength * 0.089);
 
 					if (this.team[t].player[p].stat.energy > 1) {
 						this.team[t].player[p].stat.energy = 1;

--- a/src/worker/core/GameSim.basketball.ts
+++ b/src/worker/core/GameSim.basketball.ts
@@ -546,7 +546,7 @@ class GameSim {
 	 * @return {number} Fatigue, from 0 to 1 (0 = lots of fatigue, 1 = none).
 	 */
 	fatigue(energy: number, skip?: boolean): number {
-		energy += 0.05;
+		energy += 0.1;
 
 		if (energy > 1) {
 			energy = 1;
@@ -684,7 +684,7 @@ class GameSim {
 
 						if ((numG < 2 && numPG === 0) || (numF < 2 && numC === 0)) {
 							if (
-								this.fatigue(this.team[t].player[p].stat.energy) > 0.7 &&
+								this.fatigue(this.team[t].player[p].stat.energy) > 0.63 &&
 								!onCourtIsIneligible
 							) {
 								// Exception for ridiculously tired players, so really unbalanced teams won't play starters whole game
@@ -923,8 +923,8 @@ class GameSim {
 						p,
 						"energy",
 						-possessionLength *
-							0.075 *
-							(1 - this.team[t].player[p].compositeRating.endurance),
+							0.055 *
+							(1 - this.team[t].player[p].compositeRating.endurance) ** 1.0,
 					);
 
 					if (this.team[t].player[p].stat.energy < 0) {
@@ -932,7 +932,7 @@ class GameSim {
 					}
 				} else {
 					this.recordStat(t, p, "benchTime", possessionLength);
-					this.recordStat(t, p, "energy", possessionLength * 0.1);
+					this.recordStat(t, p, "energy", possessionLength * 0.075);
 
 					if (this.team[t].player[p].stat.energy > 1) {
 						this.team[t].player[p].stat.energy = 1;


### PR DESCRIPTION
Had a lot of fun tooling around it, but I basically parameterized all the fatigue settings and then ran simulations to minimize the KL between BBGM and 40 years of NBA data for minutes played. I know load management is on the rise, but the results seemed sane to me. Existing BBGM is hard to get 40MPG, even with 100 endurance, but this is extremely common for top players (Kobe had 5 seasons above 40. Career averages: LeBron 39, Dame 36, Durant 37 in OKC, Jordan 38). 

Here are before/after results for 10 simulated seasons of MPG for current and proposed using random rosters, with NBA data for comparison. They are now both roughly mean 25, stddev = 7.7 distributions (the old one is mean = 23.5, stddev = 6.8). 
![image](https://user-images.githubusercontent.com/50534560/87277569-8ef60f00-c4b0-11ea-9eb9-fc3867fe06f5.png)


Especially with the love for "real" rosters, getting more realistic stat lines seems important, but the current fatigue settings make realistic minutes (and hence realistic per game numbers [which is what the game mostly quotes!]) literally impossible. It may seem like just a few minutes but 33 to 36MPG is 10%. 33 to 40 is 20%, and that really affects the final stat line. In my testing, taking some 66 to 75 OVR players and turning them to 100 endurance produced ~40MPG seasons, so this edit may be too small. 