### PR TITLE
added negative feedback loop on team play

### DIFF
--- a/src/worker/core/GameSim.basketball.ts
+++ b/src/worker/core/GameSim.basketball.ts
@@ -874,7 +874,13 @@ class GameSim {
 			"blocking",
 		];
 
-		for (const t of teamNums) {
+		for (let k = 0; k < teamNums.length; k++) {
+			const t = teamNums[k];
+			const oppT = teamNums[1 - k];
+			const diff = this.team[t].stat.pts - this.team[oppT].stat.pts;
+
+			const perfFactor = 1 - 0.2 * Math.tanh(diff / 60);
+
 			for (let j = 0; j < toUpdate.length; j++) {
 				const rating = toUpdate[j];
 				this.team[t].compositeRating[rating] = 0;
@@ -883,7 +889,8 @@ class GameSim {
 					const p = this.playersOnCourt[t][i];
 					this.team[t].compositeRating[rating] +=
 						this.team[t].player[p].compositeRating[rating] *
-						this.fatigue(this.team[t].player[p].stat.energy);
+						this.fatigue(this.team[t].player[p].stat.energy) *
+						perfFactor;
 				}
 
 				this.team[t].compositeRating[rating] /= 5;


### PR DESCRIPTION
This implements a feedback loop on team composite ratings. Teams winning will play worse, teams losing will play better

Model
- A linear model of 10pts = 3 NetRtg is real NBA, this is roughly Home Court Advantage (or 1% in BBGM) and could be done as 1.0 - (diff/10.0)/100.0
- TanH is linear near 0 and smoothly asymptotes, so maybe use 1 - 0.2 * tanh(diff/200) which is 0.99 when diff = 10
- This uses diff/60 as I increased this effect to bring BBGM MOV in line with realistic MOV

Results
- should not affect overall winning % as it only shrinks variance of outcomes
- average league now has only 1 team around +10 NetRtg and 6 above +5 (19-20 NBA had 1 above +10 and 6 above +5)
- This variance shrinking can be seen in the effect on MOV
![image](https://user-images.githubusercontent.com/50534560/87586292-52900200-c6ae-11ea-8218-f86746cca50f.png)

Caveat is that this only happens on team compositeRatings and doesn't affect foul drawing or shooting (neither does fatigue!)

**Qualitatively**, this should lead to fewer absurd upsets (10 better OVR team with -20 spread loses by 40 pts) and more nail-bitters, with more comebacks and close games. I think this improves overall gameplay experience for users.

In my testing, settings as aggressive as  1 - 0.3 * Math.tanh(diff / 30) still were largely correct. I just didn't want to overdo it and hence the "less aggressive" commit. 
![image](https://user-images.githubusercontent.com/50534560/87588447-afd98280-c6b1-11ea-86da-2ee21fc84989.png)

EDIT: Some quick testing shows that "good stats bad team" guys may get more minutes here, so there may be some cross reaction with #273. 