### PR TITLE
message added when award reached during god mode

### DIFF
--- a/src/worker/util/achievement.ts
+++ b/src/worker/util/achievement.ts
@@ -131,9 +131,12 @@ async function getAll(): Promise<
 
 const check = async (when: AchievementWhen, conditions: Conditions) => {
 	try {
+		/* took out this early return to explicitly let users know when achievements arent awarded.
 		if (g.get("easyDifficultyInPast") || g.get("godModeInPast")) {
 			return;
-		}
+		}*/
+
+		const tooEz = g.get("easyDifficultyInPast") || g.get("godModeInPast");
 
 		const awarded: string[] = [];
 
@@ -141,7 +144,16 @@ const check = async (when: AchievementWhen, conditions: Conditions) => {
 			if (achievement.when === when && achievement.check !== undefined) {
 				const result = await achievement.check();
 
-				if (result) {
+				if (result && tooEz) {
+					logEvent(
+						{
+							type: "achievement",
+							text: `"${achievement.name}" achievement not awarded due to Easy/God mode. <a href="/account">View all achievements.</a>`,
+							saveToDb: false,
+						},
+						conditions,
+					);
+				} else if (result && !tooEz) {
 					awarded.push(achievement.slug);
 				}
 			}


### PR DESCRIPTION
Rewrote the logic in src/worker/util/achievement.ts: took out the early return if god/easy mode was detected and instead made a logEvent message when an achievement was reached in god/easy mode. Everything else (awarding when not in god/easy mode) was left untouched. 

Lints and tests all pass, and I ran the game in my browser and made some super OP teams in god mode and ran some seasons to make sure new awards weren't being given. 
However, I did not write any new tests since I couldn't really think of any to test the desired functionality.