### PR TITLE
Franchise Leaders button in Team History

### DIFF
--- a/src/ui/views/TeamHistory/index.tsx
+++ b/src/ui/views/TeamHistory/index.tsx
@@ -61,11 +61,8 @@ const TeamHistory = ({
 				|{" "}
 				<a href={helpers.leagueUrl(["news", `${abbrev}_${tid}`])}>News Feed</a>{" "}
 				|{" "}
-				<a
-					href={helpers.leagueUrl(
-						season === undefined
-							? ["player_stats"]
-							: [
+				<a href={helpers.leagueUrl(
+						season === undefined ? ["player_stats"] : [
 									"player_stats",
 									`${abbrev}_${tid}`,
 									"career",

--- a/src/ui/views/TeamHistory/index.tsx
+++ b/src/ui/views/TeamHistory/index.tsx
@@ -59,7 +59,22 @@ const TeamHistory = ({
 					Schedule
 				</a>{" "}
 				|{" "}
-				<a href={helpers.leagueUrl(["news", `${abbrev}_${tid}`])}>News Feed</a>
+				<a href={helpers.leagueUrl(["news", `${abbrev}_${tid}`])}>News Feed</a>{" "}
+				|{" "}
+				<a
+					href={helpers.leagueUrl(
+						season === undefined
+							? ["player_stats"]
+							: [
+									"player_stats",
+									`${abbrev}_${tid}`,
+									"career",
+									process.env.SPORT === "basketball" ? "totals" : statType,
+							  ],
+					)}
+				>
+					{season === undefined ? "Per Game" : "Franchise Leaders"}
+				</a>
 			</p>
 
 			<div className="row">

--- a/src/ui/views/TeamHistory/index.tsx
+++ b/src/ui/views/TeamHistory/index.tsx
@@ -66,11 +66,11 @@ const TeamHistory = ({
 									"player_stats",
 									`${abbrev}_${tid}`,
 									"career",
-									process.env.SPORT === "basketball" ? "totals" : statType,
+									process.env.SPORT === "football" ? "passing" : "totals"
 							  ],
 					)}
 				>
-					{season === undefined ? "Per Game" : "Franchise Leaders"}
+					{"Franchise Leaders"}
 				</a>
 			</p>
 


### PR DESCRIPTION
Another very minor pr from me mainly based off of the request of many people and the most recent one being u/iCon3000. A cute little quick button to see a franchises leaders in points, assist, etc. A lot of people don't know that you can go to player stats to see this, so this button should help.
![image](https://user-images.githubusercontent.com/67447432/92421276-a22dff80-f12c-11ea-87e4-d4a87bca3ce0.png)
