### PR TITLE
eFG fix to Totals page

### DIFF
--- a/src/ui/util/helpers.ts
+++ b/src/ui/util/helpers.ts
@@ -45,6 +45,7 @@ const roundOverrides: Record<
 				fgp: "oneDecimalPlace",
 				tpp: "oneDecimalPlace",
 				"2pp": "oneDecimalPlace",
+				efg: "oneDecimalPlace",
 				ftp: "oneDecimalPlace",
 				ws48: "roundWinp",
 				pm: "plusMinus",


### PR DESCRIPTION
I forgot to add this line for my original commit for eFG%
![image](https://user-images.githubusercontent.com/67447432/93429098-74a42d00-f875-11ea-8459-d7d52f3887c5.png)
before
![image](https://user-images.githubusercontent.com/67447432/93429116-7c63d180-f875-11ea-8f4d-ffb7cd986b7c.png)
after