### PR TITLE
Fix ring not showing on players playoff section

### DIFF
--- a/src/ui/views/Player/SeasonIcons.tsx
+++ b/src/ui/views/Player/SeasonIcons.tsx
@@ -28,10 +28,10 @@ const SeasonIcons = ({
 		if (playoffs) {
 			if (award.type === "Won Championship") {
 				type = award.type;
+				countChamp += 1;
 				if (season !== undefined) {
 					break;
 				}
-				countChamp += 1;
 			}
 		} else {
 			if (award.type === "Most Valuable Player") {


### PR DESCRIPTION
You misplaced a line... rings were not appearing on playoff years when a player won a ring.

https://discord.com/channels/290013534023057409/290015591216054273/784204009757737000
