### PR TITLE
Fix playoff stats not showing when trying to view prev roster years

### DIFF
--- a/src/worker/views/roster.ts
+++ b/src/worker/views/roster.ts
@@ -174,6 +174,8 @@ const updateRoster = async (
 			players = await idb.getCopies.playersPlus(playersAll, {
 				attrs,
 				ratings,
+				playoffs: inputs.playoffs === "playoffs",
+				regularSeason: inputs.playoffs !== "playoffs",
 				stats: stats2,
 				season: inputs.season,
 				tid: inputs.tid,


### PR DESCRIPTION
Just saw this bug. Playoff stats would not show if you select to show "Playoffs" on previous seasons, only their regular seasons stats, they only will show on current year. 

Went in and found that you forgot to add these two lines for when you view previous season. This fixes the issue.

I would've just told you in #bug-reports, but I'm still a bit salty about you not merging me last time before fixing it yourself 🙄.