### PR TITLE
Fix MVPs not being counted at frivolities/draft_classes

### DIFF
--- a/src/worker/views/frivolitiesDraftClasses.ts
+++ b/src/worker/views/frivolitiesDraftClasses.ts
@@ -81,7 +81,7 @@ const updateFrivolitiesDraftClasses = async (
 				if (p.hof) {
 					draftClass.numHOF += 1;
 				}
-				if (p.awards.some(award => award.type === "Most Valueable Player")) {
+				if (p.awards.some(award => award.type === "Most Valuable Player")) {
 					draftClass.numMVP += 1;
 				}
 				if (


### PR DESCRIPTION
"Valuable" was misspelt and didn't count any MVPs on the page. Just a quick fix will get them counted.

Unrelated: I saw how you reworked the "More: " links and put it all in one file, nice stuff.