### PR TITLE
Add fun facts on error page

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -277,8 +277,7 @@ const setupRoutes = () => {
 				let errMsg: React.ReactNode = error.message;
 
 				if (errMsg === "Matching route not found") {
-					listOfOptions = ["that the lollipop is named after a famous horse named \"Lolly Pop\"", "that these fun facts are from the internet but I don't bother citing them", "Elvis only won 3 Grammys", "that it takes 700 grapes to make a bottle of wine", "that the very first alarm clock could only ring at 4 AM", "that snails can sleep for 3 years", "a B-25 plane crashed into the Empire State Building", "BBC once reported that they had no news", "that in Japan, it's a tradition to eat KFC on Christmas", "the first commercial was for Mr. Potato Head", "the White House got its name in 1901", "basketball was made so football players can stay active during the winter", "chocolate syrup was used as blood in black and white movies", "that in the Middle Ages, tomatoes were thought poisonous", "that the largest Ferris Wheel is in Dallas", "I'm blue da ba dee da ba daa", "Space Jam is the best movie", "released in 1903, Vie et Passion du Christ is the first movie in color", "2020 ÷ 5 = 404", "I'm running out of ideas", "Hawaiian pizza was made in Canada", "that these facts aren't made by Dumbmatter"];
-					errMsg = "Page not found.<p>But did you know " + listOfOptions[Math.floor(Math.random() * listOfOptions.length)] + "?</p>";
+					errMsg = "Page not found.";
 				} else if (errMsg === "League not found.") {
 					errMsg = leagueNotFoundMessage;
 				} else if (
@@ -288,7 +287,8 @@ const setupRoutes = () => {
 					if (window.bugsnagClient) {
 						window.bugsnagClient.notify(error);
 					}
-
+					const listOfOptions = ["that the lollipop is named after a famous horse named \"Lolly Pop\"", "that these fun facts are from the internet but I don't bother citing them", "Elvis only won 3 Grammys", "that it takes 700 grapes to make a bottle of wine", "that the very first alarm clock could only ring at 4 AM", "that snails can sleep for 3 years", "a B-25 plane crashed into the Empire State Building", "BBC once reported that they had no news", "that in Japan, it's a tradition to eat KFC on Christmas", "the first commercial was for Mr. Potato Head", "the White House got its name in 1901", "basketball was made so football players can stay active during the winter", "chocolate syrup was used as blood in black and white movies", "that in the Middle Ages, tomatoes were thought poisonous", "that the largest Ferris Wheel is in Dallas", "I'm blue da ba dee da ba daa",  "released in 1903, Vie et Passion du Christ is the first movie in color", "2020 ÷ 5 = 404", "Hawaiian pizza was made in Canada"];
+					const funFact = listOfOptions[Math.floor(Math.random() * listOfOptions.length);]
 					console.error("Error from view:");
 					console.error(error);
 
@@ -304,6 +304,7 @@ const setupRoutes = () => {
 						errMsg = (
 							<>
 								<h2>{errMsg}</h2>
+								<p>Did you know {funFact}?</p>
 								<p>
 									Please{" "}
 									<a

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -278,7 +278,7 @@ const setupRoutes = () => {
 
 				if (errMsg === "Matching route not found") {
 					listOfOptions = ["that the lollipop is named after a famous horse named \"Lolly Pop\"", "that these fun facts are from the internet but I don't bother citing them", "Elvis only won 3 Grammys", "that it takes 700 grapes to make a bottle of wine", "that the very first alarm clock could only ring at 4 AM", "that snails can sleep for 3 years", "a B-25 plane crashed into the Empire State Building", "BBC once reported that they had no news", "that in Japan, it's a tradition to eat KFC on Christmas", "the first commercial was for Mr. Potato Head", "the White House got its name in 1901", "basketball was made so football players can stay active during the winter", "chocolate syrup was used as blood in black and white movies", "that in the Middle Ages, tomatoes were thought poisonous", "that the largest Ferris Wheel is in Dallas", "I'm blue da ba dee da ba daa", "Space Jam is the best movie", "released in 1903, Vie et Passion du Christ is the first movie in color", "2020 ÷ 5 = 404", "I'm running out of ideas", "Hawaiian pizza was made in Canada", "that these facts aren't made by Dumbmatter"];
-					errMsg = "Page not found.<p>But did you know " + listOfOptions[Math.floor(Math.random() * listOfOptions.length)] + "</p>";
+					errMsg = "Page not found.<p>But did you know " + listOfOptions[Math.floor(Math.random() * listOfOptions.length)] + "?</p>";
 				} else if (errMsg === "League not found.") {
 					errMsg = leagueNotFoundMessage;
 				} else if (

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -277,7 +277,8 @@ const setupRoutes = () => {
 				let errMsg: React.ReactNode = error.message;
 
 				if (errMsg === "Matching route not found") {
-					errMsg = "Page not found.";
+					listOfOptions = ["that the lollipop is named after a famous horse named \"Lolly Pop\"", "that these fun facts are from the internet but I don't bother citing them", "Elvis only won 3 Grammys", "that it takes 700 grapes to make a bottle of wine", "that the very first alarm clock could only ring at 4 AM", "that snails can sleep for 3 years", "a B-25 plane crashed into the Empire State Building", "BBC once reported that they had no news", "that in Japan, it's a tradition to eat KFC on Christmas", "the first commercial was for Mr. Potato Head", "the White House got its name in 1901", "basketball was made so football players can stay active during the winter", "chocolate syrup was used as blood in black and white movies", "that in the Middle Ages, tomatoes were thought poisonous", "that the largest Ferris Wheel is in Dallas", "I'm blue da ba dee da ba daa", "Space Jam is the best movie", "released in 1903, Vie et Passion du Christ is the first movie in color", "2020 ÷ 5 = 404", "I'm running out of ideas", "Hawaiian pizza was made in Canada", "that these facts aren't made by Dumbmatter"];
+					errMsg = "Page not found.<p>But did you know " + listOfOptions[Math.floor(Math.random() * listOfOptions.length)] + "</p>";
 				} else if (errMsg === "League not found.") {
 					errMsg = leagueNotFoundMessage;
 				} else if (
@@ -302,7 +303,7 @@ const setupRoutes = () => {
 					) {
 						errMsg = (
 							<>
-								<p>{errMsg}</p>
+								<h2>{errMsg}</h2>
 								<p>
 									Please{" "}
 									<a


### PR DESCRIPTION
![error_page](https://user-images.githubusercontent.com/57536929/101915340-1b554c80-3b8b-11eb-87df-a04e7ff9e170.png)
Make the error page seem more fun.  It adds a little flavor to the error page, and it could be edited at any time.  These are fun facts that are from an old test  404 page I made a while back, so some of them may seem weird. 

It's just a fun little feature that I think is nice, and if there is a fact in here that you don't want in, then it can be removed. It's just an array, so adding and removing is super simple. 