### PR TITLE
Minor UI issues fixed

### DIFF
--- a/src/ui/util/helpers.ts
+++ b/src/ui/util/helpers.ts
@@ -214,6 +214,7 @@ const roundOverrides: Record<
 		g: "noDecimalPlace",
 		a: "noDecimalPlace",
 		pts: "noDecimalPlace",
+		oppPts: "noDecimalPlace",
 		sPct: "oneDecimalPlace",
 		svPct: "oneDecimalPlace",
 		qsPct: "oneDecimalPlace",

--- a/src/ui/views/DraftLottery.tsx
+++ b/src/ui/views/DraftLottery.tsx
@@ -15,7 +15,7 @@ const draftTypeDescriptions: Record<DraftType | "dummy", string> = {
 	nba2019: "Weighted lottery for the top 4 picks, like the NBA since 2019",
 	nba1994: "Weighted lottery for the top 3 picks, like the NBA from 1994-2018",
 	nba1990: "Weighted lottery for the top 3 picks, like the NBA from 1990-1993",
-	nhl2017: "Weighted lottery for the top 4 picks, like the NBA since 2017",
+	nhl2017: "Weighted lottery for the top 3 picks, like the NHL since 2017",
 	randomLotteryFirst3:
 		"Random lottery for the top 3 picks, like the NBA from 1987-1989",
 	randomLottery:

--- a/src/ui/views/Roster/TopStuff.tsx
+++ b/src/ui/views/Roster/TopStuff.tsx
@@ -170,9 +170,7 @@ const TopStuff = ({
 									{showTradeFor ? `Strategy: ${t.strategy}` : null}
 								</div>
 							) : null}
-							{isSport("football") ? (
-								<RosterComposition className="ml-3" players={players} />
-							) : null}
+							<RosterComposition className="ml-3" players={players} />
 						</div>
 					) : null}
 				</div>

--- a/src/ui/views/Roster/TopStuff.tsx
+++ b/src/ui/views/Roster/TopStuff.tsx
@@ -115,7 +115,7 @@ const TopStuff = ({
 		);
 
 	let marginOfVictory: string;
-	if (isSport("football")) {
+	if (isSport("football") || isSport("hockey")) {
 		if (t.stats.gp !== 0) {
 			marginOfVictory = ((t.stats.pts - t.stats.oppPts) / t.stats.gp).toFixed(
 				1,
@@ -170,7 +170,9 @@ const TopStuff = ({
 									{showTradeFor ? `Strategy: ${t.strategy}` : null}
 								</div>
 							) : null}
-							<RosterComposition className="ml-3" players={players} />
+							{isSport("football") ? (
+								<RosterComposition className="ml-3" players={players} />
+							) : null}
 						</div>
 					) : null}
 				</div>

--- a/src/ui/views/TeamHistory/RetiredJerseyNumbers.tsx
+++ b/src/ui/views/TeamHistory/RetiredJerseyNumbers.tsx
@@ -297,7 +297,11 @@ const RetiredJerseyNumbers = ({
 												{row.name}
 											</a>
 											{row.numRings > 0 ? (
-												<span title={`${row.numRings} championships`}>
+												<span
+													title={`${row.numRings} championship${
+														row.numRings > 1 ? "s" : ""
+													}`}
+												>
 													<span className="ring ml-1" />
 													{row.numRings > 1 ? (
 														<span className="text-yellow ml-1">

--- a/src/worker/util/updatePlayMenu.ts
+++ b/src/worker/util/updatePlayMenu.ts
@@ -216,7 +216,7 @@ const updatePlayMenu = async () => {
 		}
 	} else if (g.get("phase") === PHASE.PLAYOFFS) {
 		// Playoffs
-		if (isSport("basketball")) {
+		if (isSport("basketball") || isSport("hockey")) {
 			keys = ["day", "dayLive", "untilEndOfRound", "throughPlayoffs"];
 		} else {
 			keys = ["week", "weekLive", "untilEndOfRound", "throughPlayoffs"];


### PR DESCRIPTION
This has to be the least I can do to save you some time.

---

Line added in `util/helpers` is to get rid of the unnecessary decimal on the "Opp" column in standings.

Added `isSport("hockey")` to that line in `Roster/TopStuff` to fix the weird MOV on roster page.

`updatePlayMenu.ts` change is to allow people to sim one day/game in playoffs.

`RetiredJerseyNumbers.tsx` change is to make "championships" not be plural when a player only won 1 ring.