### PR TITLE
God mode option to change number of fouls needed for bonus

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -378,6 +378,7 @@ export type GameAttributesLeague = {
 	elamPoints: number;
 	equalizeRegions: boolean;
 	foulsNeededToFoulOut: number;
+	foulsUntilBonus: number[];
 	foulRateFactor: number;
 	gameOver: boolean;
 	godMode: boolean;

--- a/src/ui/views/Settings.tsx
+++ b/src/ui/views/Settings.tsx
@@ -829,6 +829,9 @@ if (isSport("basketball")) {
 				if (!Array.isArray(value)) {
 					throw new Error("Must be an array");
 				}
+				if (value.length < 3 || value.length > 3) {
+					throw new Error("Must have 3 numbers");
+				}
 				for (const num of value) {
 					if (!Number.isInteger(num)) {
 						throw new Error("Array must contain only integers");

--- a/src/ui/views/Settings.tsx
+++ b/src/ui/views/Settings.tsx
@@ -813,15 +813,13 @@ if (isSport("basketball")) {
 			key: "foulsUntilBonus",
 			name: "# of Fouls Until Teams Enter Bonus",
 			godModeRequired: "always",
-			descriptionLong: (
+			description: (
 				<>
-					<p>
-						Specify the # of fouls a team needs before they enter the penalty.
-						You must enter a valid JSON array of integers. The first #
-						determines the # of fouls needed to enter the bonus in a period. The
-						second determines the # of fouls until bonus for overtime. The third
-						determines last two minutes.
-					</p>
+					Specify the # of fouls a team needs before they enter the penalty. You
+					must enter a valid JSON array of integers. Each number determines # of
+					fouls needed to enter bonus at different parts of a game. 1st
+					determines # for periods, 2nd determines # for overtime, 3rd
+					determines # in last 2 minutes.
 				</>
 			),
 			type: "jsonString",
@@ -835,6 +833,9 @@ if (isSport("basketball")) {
 				for (const num of value) {
 					if (!Number.isInteger(num)) {
 						throw new Error("Array must contain only integers");
+					}
+					if (num < 0) {
+						throw new Error("Values cannot be less than 0");
 					}
 				}
 			},

--- a/src/ui/views/Settings.tsx
+++ b/src/ui/views/Settings.tsx
@@ -64,6 +64,7 @@ type Key =
 	| "allStarGame"
 	| "foulRateFactor"
 	| "foulsNeededToFoulOut"
+	| "foulsUntilBonus"
 	| "threePointers"
 	| "pace"
 	| "threePointTendencyFactor"
@@ -804,6 +805,34 @@ if (isSport("basketball")) {
 			validator: value => {
 				if (value < 0) {
 					throw new Error("Value cannot be less than 0");
+				}
+			},
+		},
+		{
+			category: "Game Simulation",
+			key: "foulsUntilBonus",
+			name: "# of Fouls Until Teams Enter Bonus",
+			godModeRequired: "always",
+			descriptionLong: (
+				<>
+					<p>
+						Specify the # of fouls a team needs before they enter the penalty.
+						You must enter a valid JSON array of integers. The first #
+						determines the # of fouls needed to enter the bonus in a period. The
+						second determines the # of fouls until bonus for overtime. The third
+						determines last two minutes.
+					</p>
+				</>
+			),
+			type: "jsonString",
+			validator: value => {
+				if (!Array.isArray(value)) {
+					throw new Error("Must be an array");
+				}
+				for (const num of value) {
+					if (!Number.isInteger(num)) {
+						throw new Error("Array must contain only integers");
+					}
 				}
 			},
 		},
@@ -2374,6 +2403,7 @@ Settings.propTypes = {
 	numSeasonsFutureDraftPicks: PropTypes.number.isRequired,
 	foulRateFactor: PropTypes.number.isRequired,
 	foulsNeededToFoulOut: PropTypes.number.isRequired,
+	foulsUntilBonus: PropTypes.arrayOf(PropTypes.number).isRequired,
 };
 
 export default Settings;

--- a/src/worker/core/GameSim.basketball/index.ts
+++ b/src/worker/core/GameSim.basketball/index.ts
@@ -1191,9 +1191,11 @@ class GameSim {
 		if (Math.random() < 0.08 * g.get("foulRateFactor") || intentionalFoul) {
 			// In the bonus? Checking >=1 for foulsLastTwoMinutes because incrementing this counter is done in this.doPf below
 			const inBonus =
-				(this.t <= 2 && this.foulsLastTwoMinutes[this.d] >= 1) ||
-				(this.overtimes >= 1 && this.foulsThisQuarter[this.d] >= 4) ||
-				this.foulsThisQuarter[this.d] >= 5;
+				(this.t <= 2 &&
+					this.foulsLastTwoMinutes[this.d] >= g.get("foulsUntilBonus")[2]) ||
+				(this.overtimes >= 1 &&
+					this.foulsThisQuarter[this.d] >= g.get("foulsUntilBonus")[1]) ||
+				this.foulsThisQuarter[this.d] >= g.get("foulsUntilBonus")[0];
 
 			if (inBonus) {
 				this.doPf(this.d, "pfBonus", shooter);

--- a/src/worker/util/defaultGameAttributes.ts
+++ b/src/worker/util/defaultGameAttributes.ts
@@ -83,6 +83,7 @@ const defaultGameAttributes: GameAttributesLeagueWithHistory = {
 	numSeasonsFutureDraftPicks: 4,
 	foulRateFactor: 1,
 	foulsNeededToFoulOut: 6,
+	foulsUntilBonus: [5, 4, 1],
 	rookieContractLengths: [3, 2],
 	rookiesCanRefuse: true,
 

--- a/src/worker/views/settings.ts
+++ b/src/worker/views/settings.ts
@@ -40,6 +40,7 @@ const updateSettings = async (inputs: unknown, updateEvents: UpdateEvents) => {
 			numSeasonsFutureDraftPicks: g.get("numSeasonsFutureDraftPicks"),
 			foulRateFactor: g.get("foulRateFactor"),
 			foulsNeededToFoulOut: g.get("foulsNeededToFoulOut"),
+			foulsUntilBonus: g.get("foulsUntilBonus"),
 			threePointers: g.get("threePointers"),
 			pace: g.get("pace"),
 			threePointTendencyFactor: g.get("threePointTendencyFactor"),


### PR DESCRIPTION
https://discord.com/channels/290013534023057409/331882115119448065/805026506283810847

Works well, allows more ability to recreate the rules of [other basketball leagues](https://www.fiba.basketball/rule-differences)

I went with the approach of forcing it all in one setting because 3 individual settings would be redundant. No bugs have emerged from this. Although it is possible to enter an invalid setting in a league file, it does not break leagues or game sim.