### PR TITLE
Display GPS on tables next to OPS, DPS

### DIFF
--- a/src/worker/api/index.ts
+++ b/src/worker/api/index.ts
@@ -1368,7 +1368,7 @@ const getTradingBlockOffers = async (pids: number[], dpids: number[]) => {
 		const stats = bySport({
 			basketball: ["gp", "min", "pts", "trb", "ast", "per"],
 			football: ["gp", "keyStats", "av"],
-			hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+			hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 		});
 
 		// Take the pids and dpids in each offer and get the info needed to display the offer

--- a/src/worker/views/draft.ts
+++ b/src/worker/views/draft.ts
@@ -63,7 +63,7 @@ const updateDraft = async (inputs: unknown, updateEvents: UpdateEvents) => {
 			stats = bySport({
 				basketball: ["per", "ewa"],
 				football: ["gp", "keyStats", "av"],
-				hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+				hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 			});
 			undrafted = await idb.cache.players.indexGetAll(
 				"playersByTid",
@@ -76,7 +76,7 @@ const updateDraft = async (inputs: unknown, updateEvents: UpdateEvents) => {
 			stats = bySport({
 				basketball: ["per", "ewa"],
 				football: ["gp", "keyStats", "av"],
-				hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+				hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 			});
 			undrafted = (
 				await idb.cache.players.indexGetAll("playersByTid", [0, Infinity])

--- a/src/worker/views/draftSummary.ts
+++ b/src/worker/views/draftSummary.ts
@@ -10,7 +10,7 @@ const updateDraftSummary = async (inputs: ViewInput<"draftSummary">) => {
 	const stats = bySport({
 		basketball: ["gp", "min", "pts", "trb", "ast", "per", "ws"],
 		football: ["gp", "keyStats", "av"],
-		hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+		hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 	});
 
 	let playersAll;

--- a/src/worker/views/draftTeamHistory.ts
+++ b/src/worker/views/draftTeamHistory.ts
@@ -22,7 +22,7 @@ const updateDraftTeamHistory = async (
 	const stats = bySport({
 		basketball: ["gp", "min", "pts", "trb", "ast", "per", "ws"],
 		football: ["gp", "keyStats", "av"],
-		hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+		hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 	});
 	const playersAll2 = await idb.getCopies.players({
 		filter,

--- a/src/worker/views/freeAgents.ts
+++ b/src/worker/views/freeAgents.ts
@@ -20,7 +20,7 @@ const updateFreeAgents = async () => {
 	const stats = bySport({
 		basketball: ["min", "pts", "trb", "ast", "per"],
 		football: ["gp", "keyStats", "av"],
-		hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+		hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 	});
 
 	for (const p of playersAll) {

--- a/src/worker/views/frivolitiesDraftClasses.ts
+++ b/src/worker/views/frivolitiesDraftClasses.ts
@@ -114,7 +114,7 @@ const updateFrivolitiesDraftClasses = async (
 				"ws48",
 			],
 			football: ["gp", "keyStats", "av"],
-			hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+			hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 		});
 
 		const bestPlayersAll = draftClasses.map(

--- a/src/worker/views/leagueDashboard.ts
+++ b/src/worker/views/leagueDashboard.ts
@@ -173,7 +173,7 @@ const updatePlayers = async (inputs: unknown, updateEvents: UpdateEvents) => {
 		const startersStats = bySport({
 			basketball: ["gp", "min", "pts", "trb", "ast", "per"],
 			football: ["gp", "keyStats", "av"],
-			hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+			hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 		});
 		const leaderStats = bySport({
 			basketball: ["pts", "trb", "ast"],

--- a/src/worker/views/most.ts
+++ b/src/worker/views/most.ts
@@ -63,7 +63,7 @@ export const getMostXPlayers = async ({
 	const stats = bySport({
 		basketball: ["gp", "min", "pts", "trb", "ast", "per", "ewa", "ws", "ws48"],
 		football: ["gp", "keyStats", "av"],
-		hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+		hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 	});
 
 	const players = await idb.getCopies.playersPlus(playersAll, {

--- a/src/worker/views/relatives.ts
+++ b/src/worker/views/relatives.ts
@@ -23,7 +23,7 @@ const updatePlayers = async (
 				"ws48",
 			],
 			football: ["gp", "keyStats", "av"],
-			hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+			hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 		});
 
 		let playersAll: Player[] = [];

--- a/src/worker/views/roster.ts
+++ b/src/worker/views/roster.ts
@@ -38,7 +38,7 @@ const updateRoster = async (
 		const stats = bySport({
 			basketball: ["gp", "min", "pts", "trb", "ast", "per"],
 			football: ["gp", "keyStats", "av"],
-			hockey: ["gp", "amin", "keyStats", "ops", "dps", "ps"],
+			hockey: ["gp", "amin", "keyStats", "ops", "dps", "gps", "ps"],
 		});
 
 		const editable =

--- a/src/worker/views/teamHistory.ts
+++ b/src/worker/views/teamHistory.ts
@@ -103,7 +103,7 @@ export const getHistory = async (
 	const stats = bySport({
 		basketball: ["gp", "min", "pts", "trb", "ast", "per", "ewa"],
 		football: ["gp", "keyStats", "av"],
-		hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+		hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 	});
 
 	let players = await idb.getCopies.playersPlus(playersAll, {

--- a/src/worker/views/trade.ts
+++ b/src/worker/views/trade.ts
@@ -100,7 +100,7 @@ const updateTrade = async () => {
 	const stats = bySport({
 		basketball: ["gp", "min", "pts", "trb", "ast", "per"],
 		football: ["gp", "keyStats", "av"],
-		hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+		hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 	});
 	const userRoster = await idb.getCopies.playersPlus(userRosterAll, {
 		attrs,

--- a/src/worker/views/tradingBlock.ts
+++ b/src/worker/views/tradingBlock.ts
@@ -16,7 +16,7 @@ const updateUserRoster = async (
 		const stats = bySport({
 			basketball: ["gp", "min", "pts", "trb", "ast", "per"],
 			football: ["gp", "keyStats", "av"],
-			hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+			hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 		});
 		const [userRosterAll, userPicks] = await Promise.all([
 			idb.cache.players.indexGetAll("playersByTid", g.get("userTid")),

--- a/src/worker/views/upcomingFreeAgents.ts
+++ b/src/worker/views/upcomingFreeAgents.ts
@@ -10,7 +10,7 @@ const updateUpcomingFreeAgents = async (
 	const stats = bySport({
 		basketball: ["min", "pts", "trb", "ast", "per"],
 		football: ["gp", "keyStats", "av"],
-		hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+		hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 	});
 
 	const showActualFreeAgents =

--- a/src/worker/views/watchList.ts
+++ b/src/worker/views/watchList.ts
@@ -34,7 +34,7 @@ const updatePlayers = async (
 				"ewa",
 			],
 			football: ["gp", "keyStats", "av"],
-			hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+			hockey: ["gp", "keyStats", "ops", "dps", "gps", "ps"],
 		});
 
 		const playersAll = await idb.getCopies.players({


### PR DESCRIPTION
On the fence about this pr because I feel like you have a reason for not including GPS on a lot of tables, but it feels pretty awkward going to total stats and trying to find the best goalies by sorting PS and text filtering for G's.