### PR TITLE
Change some settings to not need God mode

### DIFF
--- a/src/ui/views/Settings.tsx
+++ b/src/ui/views/Settings.tsx
@@ -165,7 +165,6 @@ export const options: {
 		category: "Season",
 		key: "numGames",
 		name: "# Games Per Season",
-		godModeRequired: "always",
 		type: "int",
 		description: "This will only apply to seasons that have not started yet.",
 	},
@@ -192,7 +191,6 @@ export const options: {
 		category: "Season",
 		key: "numGamesPlayoffSeries",
 		name: "# Playoff Games",
-		godModeRequired: "existingLeagueOnly",
 		description: (
 			<>
 				Specify the number of games in each round. You must enter a valid JSON
@@ -224,7 +222,6 @@ export const options: {
 		category: "Season",
 		key: "numPlayoffByes",
 		name: "# First Round Byes",
-		godModeRequired: "existingLeagueOnly",
 		type: "int",
 		description:
 			"Number of playoff teams who will get a bye in the first round. For leagues with two conferences, byes will be split evenly across conferences.",
@@ -716,7 +713,6 @@ export const options: {
 		category: "Game Modes",
 		key: "spectator",
 		name: "Spectator Mode",
-		godModeRequired: "always",
 		type: "bool",
 		description:
 			"In spectator mode, the AI controls all teams and you get to watch the league evolve. This is similar to Tools > Auto Play, but it lets you play through the season at your own pace.",


### PR DESCRIPTION
I've changed some settings in the League Settings option.  
These will include Games Per Season, Playoff Games, First Round Byes and Spectator Mode.  
This may seem a bit weird, but here's why I did it.
* Playoff Games and Bye
  * When you are playing and then add more teams via expansion draft, it playoffs can get a little messed up based on the amount of teams you add. I mean, if you add 6 more teams, you have 36 teams, and 20 lottery teams. Majority of the league shouldn't have a lottery pick, and if you add 10 teams, you'll have 24 teams getting a lottery pick. It'll be nice to add teams, change the playoffs without having to turn on God Mode.
* Games Per Season
  *  I sometimes like to create a league with 6 teams, then add more as we go on. Making a league that seems historical (like starting it in the 50's and having 6 teams and 30 games), and then add teams and games as time goes on. It'll be nice to have this option to play legitly, and then don't have to turn on God mode.
* Spectator Mode
  * I just added this because you can do autoplay without God Mode, but you need God Mode to turn on Spectator mode.  