### PR TITLE
Remove skills on name column in draft history

### DIFF
--- a/src/ui/views/DraftSummary.tsx
+++ b/src/ui/views/DraftSummary.tsx
@@ -112,11 +112,7 @@ const DraftSummary = ({
 				{
 					value: (
 						<div className="d-flex">
-							<PlayerNameLabels
-								pid={p.pid}
-								skills={p.currentSkills}
-								watch={p.watch}
-							>
+							<PlayerNameLabels pid={p.pid} watch={p.watch}>
 								{p.name}
 							</PlayerNameLabels>
 							<div className="ml-auto">


### PR DESCRIPTION
The left circle is what this pull request is removing. Makes the page look way cleaner, also reduces table size a good bit since the skills actually widen the table if a player with a long name has a lot of skills.

<img src=https://user-images.githubusercontent.com/67447432/111097628-2196f400-84ff-11eb-81be-3e32e08e6071.png width="575" height="225">
